### PR TITLE
Sdk cli approval origin functions

### DIFF
--- a/packages/cli/src/actions/approveMarket.ts
+++ b/packages/cli/src/actions/approveMarket.ts
@@ -1,0 +1,25 @@
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
+
+type Options = {
+  endpoint: string;
+  marketId: string;
+  outcome: string;
+  seed: string;
+};
+
+const approveMarket = async (opts: Options): Promise<void> => {
+  const { endpoint, marketId, seed } = opts;
+
+  const sdk = await SDK.initialize(endpoint);
+
+  const signer = util.signerFromSeed(seed);
+
+  const market = await sdk.models.fetchMarketData(Number(marketId));
+  const res = await market.approve(signer);
+
+  console.log(res);
+  return;
+};
+
+export default approveMarket;

--- a/packages/cli/src/actions/approveMarket.ts
+++ b/packages/cli/src/actions/approveMarket.ts
@@ -1,5 +1,4 @@
-// import SDK, { util } from "@zeitgeistpm/sdk";
-import SDK, { util } from "../../../sdk/src";
+import SDK, { util } from "@zeitgeistpm/sdk";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/approveMarket.ts
+++ b/packages/cli/src/actions/approveMarket.ts
@@ -1,4 +1,5 @@
-import SDK, { util } from "@zeitgeistpm/sdk";
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/cancelPendingMarket.ts
+++ b/packages/cli/src/actions/cancelPendingMarket.ts
@@ -1,5 +1,4 @@
-// import SDK, { util } from "@zeitgeistpm/sdk";
-import SDK, { util } from "../../../sdk/src";
+import SDK, { util } from "@zeitgeistpm/sdk";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/cancelPendingMarket.ts
+++ b/packages/cli/src/actions/cancelPendingMarket.ts
@@ -1,4 +1,5 @@
-import SDK, { util } from "@zeitgeistpm/sdk";
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/cancelPendingMarket.ts
+++ b/packages/cli/src/actions/cancelPendingMarket.ts
@@ -1,0 +1,25 @@
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
+
+type Options = {
+  endpoint: string;
+  marketId: string;
+  outcome: string;
+  seed: string;
+};
+
+const cancelPendingMarket = async (opts: Options): Promise<void> => {
+  const { endpoint, marketId, seed } = opts;
+
+  const sdk = await SDK.initialize(endpoint);
+
+  const signer = util.signerFromSeed(seed);
+
+  const market = await sdk.models.fetchMarketData(Number(marketId));
+  const res = await market.cancelAdvised(signer);
+
+  console.log(res);
+  return;
+};
+
+export default cancelPendingMarket;

--- a/packages/cli/src/actions/rejectMarket.ts
+++ b/packages/cli/src/actions/rejectMarket.ts
@@ -1,0 +1,25 @@
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
+
+type Options = {
+  endpoint: string;
+  marketId: string;
+  outcome: string;
+  seed: string;
+};
+
+const rejectMarket = async (opts: Options): Promise<void> => {
+  const { endpoint, marketId, seed } = opts;
+
+  const sdk = await SDK.initialize(endpoint);
+
+  const signer = util.signerFromSeed(seed);
+
+  const market = await sdk.models.fetchMarketData(Number(marketId));
+  // const res = await market.reject(signer);
+
+  // console.log(res);
+  return;
+};
+
+export default rejectMarket;

--- a/packages/cli/src/actions/rejectMarket.ts
+++ b/packages/cli/src/actions/rejectMarket.ts
@@ -1,5 +1,4 @@
-// import SDK, { util } from "@zeitgeistpm/sdk";
-import SDK, { util } from "../../../sdk/src";
+import SDK, { util } from "@zeitgeistpm/sdk";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/rejectMarket.ts
+++ b/packages/cli/src/actions/rejectMarket.ts
@@ -1,4 +1,5 @@
-import SDK, { util } from "@zeitgeistpm/sdk";
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/rejectMarket.ts
+++ b/packages/cli/src/actions/rejectMarket.ts
@@ -16,9 +16,9 @@ const rejectMarket = async (opts: Options): Promise<void> => {
   const signer = util.signerFromSeed(seed);
 
   const market = await sdk.models.fetchMarketData(Number(marketId));
-  // const res = await market.reject(signer);
+  const res = await market.reject(signer);
 
-  // console.log(res);
+  console.log(res);
   return;
 };
 

--- a/packages/cli/src/actions/viewMarket.ts
+++ b/packages/cli/src/actions/viewMarket.ts
@@ -1,4 +1,5 @@
-import SDK from "@zeitgeistpm/sdk";
+// import SDK, { util } from "@zeitgeistpm/sdk";
+import SDK, { util } from "../../../sdk/src";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/actions/viewMarket.ts
+++ b/packages/cli/src/actions/viewMarket.ts
@@ -1,5 +1,4 @@
-// import SDK, { util } from "@zeitgeistpm/sdk";
-import SDK, { util } from "../../../sdk/src";
+import SDK from "@zeitgeistpm/sdk";
 
 type Options = {
   endpoint: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,8 @@ import wrapNativeCurrency from "./actions/wrapNativeCurrency";
 import transfer from "./actions/transfer";
 import redeemShares from "./actions/redeemShares";
 import getAssetsPrices from "./actions/getAssetsPrices";
+import approveMarket from "./actions/approveMarket";
+import rejectMarket from "./actions/rejectMarket";
 
 /** Wrapper function to catch errors and exit. */
 const catchErrorsAndExit = async (fn: any, opts: any) => {
@@ -374,6 +376,38 @@ program
         transfer,
         Object.assign(opts, { marketId, sharesIndex, to, amount })
       )
+  );
+
+program
+  .command("approveMarket <marketId>")
+  .option(
+    "--seed <string>",
+    "The signer's seed. Must be an ApprovalOrigin. Default is `//Alice`.",
+    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
+  )
+  .option(
+    "--endpoint <string>",
+    "The endpoint to connect the API to.",
+    "wss://bp-rpc.zeitgeist.pm"
+  )
+  .action((marketId: number, opts: any) =>
+    catchErrorsAndExit(approveMarket, Object.assign(opts, { marketId }))
+  );
+
+program
+  .command("rejectMarket <marketId>")
+  .option(
+    "--seed <string>",
+    "The signer's seed. Must be an ApprovalOrigin. Default is `//Alice`.",
+    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
+  )
+  .option(
+    "--endpoint <string>",
+    "The endpoint to connect the API to.",
+    "wss://bp-rpc.zeitgeist.pm"
+  )
+  .action((marketId: number, opts: any) =>
+    catchErrorsAndExit(rejectMarket, Object.assign(opts, { marketId }))
   );
 
 program.parse(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -73,14 +73,14 @@ program
 program
   .command("cancelMarket <marketId>")
   .option(
-    "--endpoint <string>",
-    "The endpoint to connect the API to.",
-    "wss://bp-rpc.zeitgeist.pm"
-  )
-  .option(
     "--seed <string>",
     "The signer's seed. Default is `//Alice`.",
     "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
+  )
+  .option(
+    "--endpoint <string>",
+    "The endpoint to connect the API to.",
+    "wss://bp-rpc.zeitgeist.pm"
   )
   .action((marketId: number, opts: any) =>
     catchErrorsAndExit(cancelPendingMarket, Object.assign(opts, { marketId }))
@@ -418,14 +418,14 @@ program
 program
   .command("approveMarket <marketId>")
   .option(
-    "--seed <string>",
-    "The signer's seed. Must be an ApprovalOrigin. Default is `//Alice`.",
-    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
-  )
-  .option(
     "--endpoint <string>",
     "The endpoint to connect the API to.",
     "wss://bp-rpc.zeitgeist.pm"
+  )
+  .option(
+    "--seed <string>",
+    "The signer's seed. Must be an ApprovalOrigin. Default is `//Alice`.",
+    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
   )
   .action((marketId: number, opts: any) =>
     catchErrorsAndExit(approveMarket, Object.assign(opts, { marketId }))
@@ -434,14 +434,14 @@ program
 program
   .command("rejectMarket <marketId>")
   .option(
-    "--seed <string>",
-    "The signer's seed. Must be an ApprovalOrigin. Default is `//Alice`.",
-    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
-  )
-  .option(
     "--endpoint <string>",
     "The endpoint to connect the API to.",
     "wss://bp-rpc.zeitgeist.pm"
+  )
+  .option(
+    "--seed <string>",
+    "The signer's seed. Must be an ApprovalOrigin. Default is `//Alice`.",
+    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
   )
   .action((marketId: number, opts: any) =>
     catchErrorsAndExit(rejectMarket, Object.assign(opts, { marketId }))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import program from "commander";
 
 import buyCompleteSet from "./actions/buyCompleteSet";
 import createMarket from "./actions/createMarket";
+import cancelPendingMarket from "./actions/cancelPendingMarket";
 import disputeMarket from "./actions/disputeMarket";
 import reportMarket from "./actions/reportMarket";
 import deployPool from "./actions/deployPool";
@@ -67,6 +68,22 @@ program
   )
   .action((marketId: number, opts: any) =>
     catchErrorsAndExit(viewMarket, Object.assign(opts, { marketId }))
+  );
+
+program
+  .command("cancelMarket <marketId>")
+  .option(
+    "--endpoint <string>",
+    "The endpoint to connect the API to.",
+    "wss://bp-rpc.zeitgeist.pm"
+  )
+  .option(
+    "--seed <string>",
+    "The signer's seed. Default is `//Alice`.",
+    "clean useful exotic shoe day rural hotel pitch manual happy inherit concert"
+  )
+  .action((marketId: number, opts: any) =>
+    catchErrorsAndExit(cancelPendingMarket, Object.assign(opts, { marketId }))
   );
 
 program

--- a/packages/sdk/src/models/market.ts
+++ b/packages/sdk/src/models/market.ts
@@ -462,10 +462,10 @@ class Market {
     };
 
     return new Promise(async (resolve) => {
-        const call = await this.api.tx.predictionMarkets
-          .approveMarket(this.marketId);
+      const call = await this.api.tx.predictionMarkets
+        .approveMarket(this.marketId);
 
-        const sudoTx = await this.api.tx.sudo.sudo(call);
+      const sudoTx = await this.api.tx.sudo.sudo(call);
         
       if (isExtSigner(signer)) {
         const unsub = await sudoTx
@@ -474,7 +474,7 @@ class Market {
               ? callback(result, unsub)
               : _callback(result, resolve, unsub)
           );
-      } else {        
+      } else {
         const unsub = await sudoTx
           .signAndSend(signer, (result) =>
             callback
@@ -514,11 +514,11 @@ class Market {
     };
 
     return new Promise(async (resolve) => {
-        const call = await this.api.tx.predictionMarkets
-          .rejectMarket(this.marketId);
+      const call = await this.api.tx.predictionMarkets
+        .rejectMarket(this.marketId);
 
-        const sudoTx = await this.api.tx.sudo.sudo(call);
-        
+      const sudoTx = await this.api.tx.sudo.sudo(call);
+
       if (isExtSigner(signer)) {
         const unsub = await sudoTx
           .signAndSend(signer.address, { signer: signer.signer }, (result) =>
@@ -526,7 +526,7 @@ class Market {
               ? callback(result, unsub)
               : _callback(result, resolve, unsub)
           );
-      } else {        
+      } else {
         const unsub = await sudoTx
           .signAndSend(signer, (result) =>
             callback

--- a/packages/sdk/src/models/market.ts
+++ b/packages/sdk/src/models/market.ts
@@ -432,6 +432,160 @@ class Market {
       }
     });
   }
+
+  async approve(
+    signer: KeyringPairOrExtSigner,
+    callback?: (result: ISubmittableResult, _unsub: () => void) => void
+  ): Promise<string> {
+    const _callback = (
+      result: ISubmittableResult,
+      _resolve: (value: string | PromiseLike<string>) => void,
+      _unsub: () => void
+    ) => {
+      const { events, status } = result;
+      console.log("status:", status.toHuman());
+
+      if (status.isInBlock) {
+        events.forEach(({ phase, event: { data, method, section } }) => {
+          console.log(`\t' ${phase}: ${section}.${method}:: ${data}`);
+
+          if (method == "MarketApproved") {
+            _resolve(data[0].toString());
+          }
+          if (method == "ExtrinsicFailed") {
+            _resolve("");
+          }
+
+          unsubOrWarns(_unsub);
+        });
+      }
+    };
+
+    return new Promise(async (resolve) => {
+        const call = await this.api.tx.predictionMarkets
+          .approveMarket(this.marketId);
+
+        const sudoTx = await this.api.tx.sudo.sudo(call);
+        
+      if (isExtSigner(signer)) {
+        const unsub = await sudoTx
+          .signAndSend(signer.address, { signer: signer.signer }, (result) =>
+            callback
+              ? callback(result, unsub)
+              : _callback(result, resolve, unsub)
+          );
+      } else {        
+        const unsub = await sudoTx
+          .signAndSend(signer, (result) =>
+            callback
+              ? callback(result, unsub)
+              : _callback(result, resolve, unsub)
+          );
+      }
+    });
+  }
+
+  async reject(
+    signer: KeyringPairOrExtSigner,
+    callback?: (result: ISubmittableResult, _unsub: () => void) => void
+  ): Promise<string> {
+    const _callback = (
+      result: ISubmittableResult,
+      _resolve: (value: string | PromiseLike<string>) => void,
+      _unsub: () => void
+    ) => {
+      const { events, status } = result;
+      console.log("status:", status.toHuman());
+
+      if (status.isInBlock) {
+        events.forEach(({ phase, event: { data, method, section } }) => {
+          console.log(`\t' ${phase}: ${section}.${method}:: ${data}`);
+
+          if (method == "MarketRejected") {
+            _resolve(data[0].toString());
+          }
+          if (method == "ExtrinsicFailed") {
+            _resolve("");
+          }
+
+          unsubOrWarns(_unsub);
+        });
+      }
+    };
+
+    return new Promise(async (resolve) => {
+        const call = await this.api.tx.predictionMarkets
+          .rejectMarket(this.marketId);
+
+        const sudoTx = await this.api.tx.sudo.sudo(call);
+        
+      if (isExtSigner(signer)) {
+        const unsub = await sudoTx
+          .signAndSend(signer.address, { signer: signer.signer }, (result) =>
+            callback
+              ? callback(result, unsub)
+              : _callback(result, resolve, unsub)
+          );
+      } else {        
+        const unsub = await sudoTx
+          .signAndSend(signer, (result) =>
+            callback
+              ? callback(result, unsub)
+              : _callback(result, resolve, unsub)
+          );
+      }
+    });
+  }
+
+  async cancelAdvised(
+    signer: KeyringPairOrExtSigner,
+    callback?: (result: ISubmittableResult, _unsub: () => void) => void
+  ): Promise<string> {
+    const _callback = (
+      result: ISubmittableResult,
+      _resolve: (value: string | PromiseLike<string>) => void,
+      _unsub: () => void
+    ) => {
+      const { events, status } = result;
+      console.log("status:", status.toHuman());
+
+      if (status.isInBlock) {
+        events.forEach(({ phase, event: { data, method, section } }) => {
+          console.log(`\t' ${phase}: ${section}.${method}:: ${data}`);
+
+          if (method == "MarketCancelled") {
+            _resolve(data[0].toString());
+          }
+          if (method == "ExtrinsicFailed") {
+            _resolve("");
+          }
+
+          unsubOrWarns(_unsub);
+        });
+      }
+    };
+
+    return new Promise(async (resolve) => {
+      if (isExtSigner(signer)) {
+        const unsub = await this.api.tx.predictionMarkets
+          .cancelPendingMarket(this.marketId)
+          .signAndSend(signer.address, { signer: signer.signer }, (result) =>
+            callback
+              ? callback(result, unsub)
+              : _callback(result, resolve, unsub)
+          );
+      } else {
+        const unsub = await this.api.tx.predictionMarkets
+          .cancelPendingMarket(this.marketId)
+          .signAndSend(signer, (result) =>
+            callback
+              ? callback(result, unsub)
+              : _callback(result, resolve, unsub)
+          );
+      }
+    });
+  }
+  
 }
 
 export default Market;


### PR DESCRIPTION
Adds SDK and CLI functions to access ApprovalOrigin extrinsics in prediction-markets pallet, using sudo.

Additionally some changes to CLI (--endpoint added to all commands; help strings no longer reference Alice)
(this change should be replicated exactly in PR for SDK-prediction-markets-getters)