### PR TITLE
Add typesAlias

### DIFF
--- a/packages/sdk/src/util/polkadot.ts
+++ b/packages/sdk/src/util/polkadot.ts
@@ -124,18 +124,18 @@ export const initApi = (
     },
     typesAlias: {
       tokens: {
-        //@ts-ignore
-        AccountData: {
-          free: "Balance",
-          reserved: "Balance",
-          frozen: "Balance",
-        },
+        AccountData: "TokensAccountData",
       },
     },
     types: {
       ...typesFromDefs(zeitgeistDefinitions),
       BalanceInfo: {
         amount: "Balance",
+      },
+      TokensAccountData: {
+        free: "Balance",
+        reserved: "Balance",
+        frozen: "Balance",
       },
     },
   });

--- a/packages/sdk/src/util/polkadot.ts
+++ b/packages/sdk/src/util/polkadot.ts
@@ -122,6 +122,16 @@ export const initApi = (
         },
       },
     },
+    typesAlias: {
+      tokens: {
+        //@ts-ignore
+        AccountData: {
+          free: "Balance",
+          reserved: "Balance",
+          frozen: "Balance",
+        },
+      },
+    },
     types: {
       ...typesFromDefs(zeitgeistDefinitions),
       BalanceInfo: {

--- a/packages/type-defs/src/index.ts
+++ b/packages/type-defs/src/index.ts
@@ -4,6 +4,15 @@ export { default as swaps } from "./swaps";
 
 export const index = {
   rpc: {},
+  typesAlias: {
+    tokens: {
+      AccountData: {
+        free: "Balance",
+        reserved: "Balance",
+        frozen: "Balance",
+      },
+    },
+  },
   types: {
     Address: "MultiAddress",
     Amount: "i128",
@@ -15,7 +24,7 @@ export const index = {
         CombinatorialOutcome: null,
         PoolShare: "u128",
         Ztg: null,
-      }
+      },
     },
     SerdeWrapper: "Balance",
     BlockNumber: "u64",
@@ -25,10 +34,7 @@ export const index = {
     Index: "u64",
     Lookup: "MultiAddress",
     ScalarPosition: {
-      _enum: [
-        "Long",
-        "Short"
-      ]
-    }
+      _enum: ["Long", "Short"],
+    },
   },
 };

--- a/packages/types/src/interfaces/augment-types.ts
+++ b/packages/types/src/interfaces/augment-types.ts
@@ -55,7 +55,7 @@ import type { Multiplier } from '@polkadot/types/interfaces/txpayment';
 import type { Multisig, Timepoint } from '@polkadot/types/interfaces/utility';
 import type { VestingInfo } from '@polkadot/types/interfaces/vesting';
 import type { AccountId32Junction, AccountIndex64Junction, AccountKey20Junction, AssetInstance, DoubleEncodedCall, Junction, MultiAsset, MultiAssetAbstractFungible, MultiAssetAbstractNonFungible, MultiAssetConcreteFungible, MultiAssetConcreteNonFungible, MultiLocation, NetworkId, VersionedMultiAsset, VersionedMultiLocation, VersionedXcm, Xcm, XcmAssetEffects, XcmError, XcmHrmpChannelAccepted, XcmHrmpChannelClosing, XcmHrmpNewChannelOpenRequest, XcmOrder, XcmOrderBuyExecution, XcmOrderDepositAsset, XcmOrderDepositReserveAsset, XcmOrderExchangeAsset, XcmOrderInitiateReserveWithdraw, XcmOrderInitiateTeleport, XcmOrderQueryHolding, XcmOriginKind, XcmOutcome, XcmQueryResponse, XcmRelayedFrom, XcmReserveAssetDeposit, XcmResponse, XcmTeleportAsset, XcmTransact, XcmTransferAsset, XcmTransferReserveAsset, XcmWithdrawAsset } from '@polkadot/types/interfaces/xcm';
-import type { Amount, AmountOf, Asset, BalanceInfo, CategoryIndex, CurrencyId, CurrencyIdOf, Lookup, ScalarPosition } from '@zeitgeistpm/types/interfaces/index';
+import type { Amount, AmountOf, Asset, CategoryIndex, CurrencyId, CurrencyIdOf, Lookup, ScalarPosition, SerdeWrapper } from '@zeitgeistpm/types/interfaces/index';
 import type { Order, OrderSide } from '@zeitgeistpm/types/interfaces/orderbook';
 import type { Market, MarketCreation, MarketDispute, MarketEnd, MarketId, MarketStatus, MarketType, Outcome, Report } from '@zeitgeistpm/types/interfaces/predictionMarkets';
 import type { CommonPoolEventParams, Pool, PoolAssetEvent, PoolAssetsEvent, SwapEvent } from '@zeitgeistpm/types/interfaces/swaps';
@@ -117,6 +117,7 @@ declare module '@polkadot/types/types/registry' {
     'Compact<RelayChainBlockNumber>': Compact<RelayChainBlockNumber>;
     'Compact<RewardPoint>': Compact<RewardPoint>;
     'Compact<SchedulePriority>': Compact<SchedulePriority>;
+    'Compact<SerdeWrapper>': Compact<SerdeWrapper>;
     'Compact<SessionIndex>': Compact<SessionIndex>;
     'Compact<SetId>': Compact<SetId>;
     'Compact<SetIndex>': Compact<SetIndex>;
@@ -216,7 +217,6 @@ declare module '@polkadot/types/types/registry' {
     'Option<BabeWeight>': Option<BabeWeight>;
     'Option<BackedCandidate>': Option<BackedCandidate>;
     'Option<Balance>': Option<Balance>;
-    'Option<BalanceInfo>': Option<BalanceInfo>;
     'Option<BalanceLock>': Option<BalanceLock>;
     'Option<BalanceLockTo212>': Option<BalanceLockTo212>;
     'Option<BalanceOf>': Option<BalanceOf>;
@@ -754,6 +754,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<SealV0>': Option<SealV0>;
     'Option<SeatHolder>': Option<SeatHolder>;
     'Option<SeedOf>': Option<SeedOf>;
+    'Option<SerdeWrapper>': Option<SerdeWrapper>;
     'Option<ServiceQuality>': Option<ServiceQuality>;
     'Option<SessionIndex>': Option<SessionIndex>;
     'Option<SessionInfo>': Option<SessionInfo>;
@@ -1026,7 +1027,6 @@ declare module '@polkadot/types/types/registry' {
     'Vec<BabeWeight>': Vec<BabeWeight>;
     'Vec<BackedCandidate>': Vec<BackedCandidate>;
     'Vec<Balance>': Vec<Balance>;
-    'Vec<BalanceInfo>': Vec<BalanceInfo>;
     'Vec<BalanceLock>': Vec<BalanceLock>;
     'Vec<BalanceLockTo212>': Vec<BalanceLockTo212>;
     'Vec<BalanceOf>': Vec<BalanceOf>;
@@ -1564,6 +1564,7 @@ declare module '@polkadot/types/types/registry' {
     'Vec<SealV0>': Vec<SealV0>;
     'Vec<SeatHolder>': Vec<SeatHolder>;
     'Vec<SeedOf>': Vec<SeedOf>;
+    'Vec<SerdeWrapper>': Vec<SerdeWrapper>;
     'Vec<ServiceQuality>': Vec<ServiceQuality>;
     'Vec<SessionIndex>': Vec<SessionIndex>;
     'Vec<SessionInfo>': Vec<SessionInfo>;
@@ -1836,7 +1837,6 @@ declare module '@polkadot/types/types/registry' {
     BabeWeight: BabeWeight;
     BackedCandidate: BackedCandidate;
     Balance: Balance;
-    BalanceInfo: BalanceInfo;
     BalanceLock: BalanceLock;
     BalanceLockTo212: BalanceLockTo212;
     BalanceOf: BalanceOf;
@@ -2374,6 +2374,7 @@ declare module '@polkadot/types/types/registry' {
     SealV0: SealV0;
     SeatHolder: SeatHolder;
     SeedOf: SeedOf;
+    SerdeWrapper: SerdeWrapper;
     ServiceQuality: ServiceQuality;
     SessionIndex: SessionIndex;
     SessionInfo: SessionInfo;

--- a/packages/types/src/interfaces/index/types.ts
+++ b/packages/types/src/interfaces/index/types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { Enum, Struct, i128, u128, u16, u64 } from '@polkadot/types';
+import type { Enum, i128, u128, u16, u64 } from '@polkadot/types';
 import type { ITuple } from '@polkadot/types/types';
 import type { Balance, MultiAddress } from '@polkadot/types/interfaces/runtime';
 import type { MarketId } from '@zeitgeistpm/types/interfaces/predictionMarkets';
@@ -27,11 +27,6 @@ export interface Asset extends Enum {
   readonly isZtg: boolean;
 }
 
-/** @name BalanceInfo */
-export interface BalanceInfo extends Struct {
-  readonly amount: Balance;
-}
-
 /** @name BlockNumber */
 export interface BlockNumber extends u64 {}
 
@@ -55,5 +50,8 @@ export interface ScalarPosition extends Enum {
   readonly isLong: boolean;
   readonly isShort: boolean;
 }
+
+/** @name SerdeWrapper */
+export interface SerdeWrapper extends Balance {}
 
 export type PHANTOM_INDEX = 'index';


### PR DESCRIPTION
To resolve the collision between Tokens' `AccountData` and Balances' `AccountData`. This will work for the SDK, but I don't think this will work for upstream packages that consume our type-defs package.

This is because we explicitly specify typesAlias on our API instantiation inside the SDK, but for Polkadot-JS Apps, there is no way for them to take our typesAlias. Requires a PR to Polkadot-JS Apps