### PR TITLE
Add MarketIdOf type

### DIFF
--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -183,3 +183,5 @@ export type poolExitOpts = {
 export type ExtSigner = { address: string; signer: Signer };
 
 export type KeyringPairOrExtSigner = KeyringPair | ExtSigner;
+
+export type MarketIdOf = MarketId;

--- a/packages/types/src/interfaces/augment-types.ts
+++ b/packages/types/src/interfaces/augment-types.ts
@@ -2424,6 +2424,7 @@ declare module '@polkadot/types/types/registry' {
     MarketDispute: MarketDispute;
     MarketEnd: MarketEnd;
     MarketId: MarketId;
+    MarketIdOf: MarketId;
     MarketStatus: MarketStatus;
     MarketType: MarketType;
     MaybeRandomness: MaybeRandomness;


### PR DESCRIPTION
https://github.com/zeitgeistpm/zeitgeist/pull/167 centralizes `MarketId` through the new `MarketIdOf` type.