### PR TITLE
Graphql market filtering updates

### DIFF
--- a/packages/cli/src/actions/graphql/queryFilteredMarkets.ts
+++ b/packages/cli/src/actions/graphql/queryFilteredMarkets.ts
@@ -9,6 +9,7 @@ type Options = {
   endpoint: string;
   graphQlEndpoint: string;
   statuses: MarketStatusText[];
+  tags: string[];
   ordering: MarketsOrdering;
   orderBy: MarketsOrderBy;
   pageNumber: number;
@@ -22,6 +23,7 @@ const queryFilteredMarkets = async (opts: Options): Promise<void> => {
     endpoint,
     graphQlEndpoint,
     statuses,
+    tags,
     ordering,
     orderBy,
     pageNumber,
@@ -33,7 +35,7 @@ const queryFilteredMarkets = async (opts: Options): Promise<void> => {
   const sdk = await SDK.initialize(endpoint, { graphQlEndpoint });
 
   const res = await sdk.models.filterMarkets(
-    { statuses, creator, oracle },
+    { statuses, creator, oracle, tags },
     {
       ordering,
       orderBy,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -789,7 +789,14 @@ program
     "Endpoint of the graphql query node",
     "https://processor.zeitgeist.pm/graphql"
   )
-  .option("--statuses <strings...>", "Statuses of markets to display", "Active")
+  .option(
+    "--statuses [strings...]",
+    "Statuses of markets to display. By default shows all statuses."
+  )
+  .option(
+    "--tags [strings...]",
+    "Filter markets by supplied tags. By default shows all tags."
+  )
   .option("--page-number <number>", "Page number of market results", "1")
   .option("--page-size <number>", "Page size for the results", "100")
   .option(
@@ -812,6 +819,7 @@ program
       graphQlEndpoint,
       endpoint,
       statuses,
+      tags,
       pageNumber,
       pageSize,
       ordering,
@@ -821,7 +829,8 @@ program
     }: {
       graphQlEndpoint: string;
       endpoint: string;
-      statuses: string | string[];
+      statuses?: string | string[];
+      tags?: string | string[];
       pageNumber: string;
       pageSize: string;
       ordering: string;
@@ -832,8 +841,12 @@ program
       if (typeof statuses === "string") {
         statuses = [statuses];
       }
+      if (typeof tags === "string") {
+        tags = [tags];
+      }
       catchErrorsAndExit(queryFilteredMarkets, {
         statuses,
+        tags,
         graphQlEndpoint,
         endpoint,
         pageNumber: Number(pageNumber),

--- a/packages/sdk/src/models/index.ts
+++ b/packages/sdk/src/models/index.ts
@@ -533,10 +533,12 @@ export default class Models {
   async filterMarkets(
     {
       statuses,
+      tags,
       creator,
       oracle,
     }: {
-      statuses: MarketStatusText[];
+      statuses?: MarketStatusText[];
+      tags?: string[];
       creator?: string;
       oracle?: string;
     },
@@ -553,6 +555,7 @@ export default class Models {
     const query = gql`
       query marketPage(
         $statuses: [String!]
+        $tags: [String!]
         $pageSize: Int!
         $offset: Int!
         $orderByQuery: [MarketOrderByInput!]
@@ -562,6 +565,7 @@ export default class Models {
         markets(
           where: {
             status_in: $statuses
+            tags_containsAll: $tags
             creator_eq: $creator
             oracle_eq: $oracle
           }
@@ -586,7 +590,15 @@ export default class Models {
       orderBy === "newest" ? `marketId_${orderingStr}` : `end_${orderingStr}`;
     const data = await this.graphQLClient.request<{
       markets: MarketQueryData[];
-    }>(query, { statuses, pageSize, offset, orderByQuery, creator, oracle });
+    }>(query, {
+      statuses,
+      tags,
+      pageSize,
+      offset,
+      orderByQuery,
+      creator,
+      oracle,
+    });
 
     const { markets: queriedMarkets } = data;
 


### PR DESCRIPTION
- add filtering by tags
- make statuses and tags filtering optional and if not supplied will
  show all tags and statuses

I tested this with cli and it seems to work fine. Rechecking it would be nice.