### PR TITLE
updates on subsquid querying

### DIFF
--- a/packages/cli/src/actions/graphql/queryMarket.ts
+++ b/packages/cli/src/actions/graphql/queryMarket.ts
@@ -11,7 +11,7 @@ const queryMarket = async (opts: Options): Promise<void> => {
 
   const sdk = await SDK.initialize(endpoint, { graphQlEndpoint });
 
-  const res = await sdk.models.fetchMarketData(marketId);
+  const res = await sdk.models.queryMarket(marketId);
 
   console.log(res.toJSONString());
 };

--- a/packages/cli/src/actions/graphql/queryMarketsCountForTag.ts
+++ b/packages/cli/src/actions/graphql/queryMarketsCountForTag.ts
@@ -1,5 +1,4 @@
 import SDK from "@zeitgeistpm/sdk";
-import { MarketsOrderBy, MarketsOrdering } from "@zeitgeistpm/sdk/dist/types";
 
 type Options = {
   endpoint: string;
@@ -12,9 +11,9 @@ const queryMarketsCountForTag = async (opts: Options): Promise<void> => {
 
   const sdk = await SDK.initialize(endpoint, { graphQlEndpoint });
 
-  const count = await sdk.models.queryMarketsCount( { tags: [tag]});
+  const count = await sdk.models.queryMarketsCount({ tags: [tag] });
 
-  console.log('Count: ', count);
+  console.log("Count: ", count);
 };
 
 export default queryMarketsCountForTag;

--- a/packages/cli/src/actions/graphql/queryMarketsCountForTag.ts
+++ b/packages/cli/src/actions/graphql/queryMarketsCountForTag.ts
@@ -1,0 +1,20 @@
+import SDK from "@zeitgeistpm/sdk";
+import { MarketsOrderBy, MarketsOrdering } from "@zeitgeistpm/sdk/dist/types";
+
+type Options = {
+  endpoint: string;
+  graphQlEndpoint: string;
+  tag: string;
+};
+
+const queryMarketsCountForTag = async (opts: Options): Promise<void> => {
+  const { endpoint, graphQlEndpoint, tag } = opts;
+
+  const sdk = await SDK.initialize(endpoint, { graphQlEndpoint });
+
+  const count = await sdk.models.queryMarketsCount( { tags: [tag]});
+
+  console.log('Count: ', count);
+};
+
+export default queryMarketsCountForTag;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,6 +37,7 @@ import queryAllMarketIds from "./actions/graphql/queryAllMarketIds";
 import queryMarket from "./actions/graphql/queryMarket";
 import queryFilteredMarkets from "./actions/graphql/queryFilteredMarkets";
 import queryAllActiveAssets from "./actions/graphql/queryAllActiveAssets";
+import queryMarketsCountForTag from "./actions/graphql/queryMarketsCountForTag";
 
 /** Wrapper function to catch errors and exit. */
 const catchErrorsAndExit = async (fn: any, opts: any) => {
@@ -899,6 +900,40 @@ program
       endpoint: string;
     }) => {
       catchErrorsAndExit(queryAllActiveAssets, { graphQlEndpoint, endpoint });
+    }
+  );
+
+program
+  .command("queryMarketsCountForTag")
+  .option(
+    "--endpoint <string>",
+    "The endpoint URL of the API connection",
+    "wss://bsr.zeitgeist.pm"
+  )
+  .option(
+    "--graphQlEndpoint <string>",
+    "Endpoint of the graphql query node",
+    "https://processor.zeitgeist.pm/graphql"
+  )
+  .option(
+    "--tag [string]",
+    "Filter markets by supplied tags. By default shows all tags"
+  )
+  .action(
+    ({
+      graphQlEndpoint,
+      endpoint,
+      tag,
+    }: {
+      graphQlEndpoint: string;
+      endpoint: string;
+      tag: string;
+    }) => {
+      catchErrorsAndExit(queryMarketsCountForTag, {
+        tag,
+        graphQlEndpoint,
+        endpoint,
+      });
     }
   );
 

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -252,3 +252,13 @@ export type MarketStatusText =
 export type MarketsOrdering = "asc" | "desc";
 
 export type MarketsOrderBy = "newest" | "end";
+
+export type MarketsFilteringOptions = {
+  statuses?: MarketStatusText[];
+  tags?: string[];
+  slug?: string;
+  question?: string;
+  creator?: string;
+  oracle?: string;
+  liquidityOnly?: boolean;
+};


### PR DESCRIPTION
- add method to get count for specific market filters separately #155 
- re-enable fetching markets by id with polkadotjs api #154 