### PR TITLE
Improved connection behaviour

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,10 +1,8 @@
 import { ApiPromise } from "@polkadot/api";
-import { isFunction } from "@polkadot/util";
 import { GraphQLClient, request, gql } from "graphql-request";
 
 import ErrorTable from "./errorTable";
 import Models from "./models";
-import { initApi } from "./util";
 import { lazyInitApi } from "./util/polkadot";
 
 export * as models from "./models";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,15 +71,20 @@ export default class SDK {
         15000,
         new Promise(async (resolve, reject) => {
           const [provider, create] = lazyInitApi(endpoint);
+          let finished = false;
           let connectionTries = 0;
           provider.on("error", () => {
-            connectionTries++;
-            if (connectionTries > (opts.initialConnectionTries || 5)) {
+            if (
+              !finished &&
+              connectionTries++ > (opts.initialConnectionTries || 5)
+            ) {
+              finished = true;
               provider.disconnect();
               reject("Could not connect to the node");
             }
           });
           provider.on("connected", () => {
+            finished = true;
             resolve(create());
           });
         }),

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -68,7 +68,7 @@ export default class SDK {
       const start = Date.now();
 
       const api = await SDK.promiseWithTimeout<ApiPromise>(
-        15000,
+        60 * 1000,
         new Promise(async (resolve, reject) => {
           const [provider, create] = lazyInitApi(endpoint);
           let finished = false;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -70,13 +70,13 @@ export default class SDK {
       const start = Date.now();
 
       const api = await SDK.promiseWithTimeout<ApiPromise>(
-        12000,
+        15000,
         new Promise(async (resolve, reject) => {
           const [provider, create] = lazyInitApi(endpoint);
           let connectionTries = 0;
           provider.on("error", () => {
             connectionTries++;
-            if (connectionTries > opts.initialConnectionTries) {
+            if (connectionTries > (opts.initialConnectionTries || 5)) {
               provider.disconnect();
               reject("Could not connect to the node");
             }

--- a/packages/sdk/src/util/polkadot.ts
+++ b/packages/sdk/src/util/polkadot.ts
@@ -18,128 +18,137 @@ const typesFromDefs = (
   );
 };
 
+export const constructApiOptions = (provider: WsProvider) => ({
+  provider,
+  rpc: {
+    predictionMarkets: {
+      marketOutcomeShareId: {
+        description: "Get the market outcome share identifier.",
+        params: [
+          {
+            name: "market_id",
+            type: "MarketId",
+          },
+          {
+            name: "outcome",
+            type: "u16",
+          },
+          {
+            name: "at",
+            type: "Hash",
+            isOptional: true,
+          },
+        ],
+        type: "Asset",
+      },
+    },
+    swaps: {
+      poolSharesId: {
+        description: "Gets the share identifier for the pool shares.",
+        params: [
+          {
+            name: "pool_id",
+            type: "u128",
+          },
+          {
+            name: "at",
+            type: "Hash",
+            isOptional: true,
+          },
+        ],
+        type: "Asset",
+      },
+      poolAccountId: {
+        description: "Gets the pool's account.",
+        params: [
+          {
+            name: "pool_id",
+            type: "u128",
+          },
+          {
+            name: "at",
+            type: "Hash",
+            isOptional: true,
+          },
+        ],
+        type: "AccountId",
+      },
+      getSpotPrice: {
+        description: "Gets the spot price for a pool's in and out assets.",
+        params: [
+          {
+            name: "pool_id",
+            type: "u128",
+          },
+          {
+            name: "asset_in",
+            type: "Asset",
+          },
+          {
+            name: "asset_out",
+            type: "Asset",
+          },
+          {
+            name: "at",
+            type: "Hash",
+            isOptional: true,
+          },
+        ],
+        type: "SerdeWrapper",
+      },
+      getSpotPrices: {
+        description: "Gets spot prices for a range of blocks",
+        params: [
+          {
+            name: "pool_id",
+            type: "u128",
+          },
+          {
+            name: "asset_in",
+            type: "Asset",
+          },
+          {
+            name: "asset_out",
+            type: "Asset",
+          },
+          {
+            name: "blocks",
+            type: "Vec<BlockNumber>",
+          },
+        ],
+        type: "Vec<SerdeWrapper>",
+      },
+    },
+  },
+  typesAlias: {
+    tokens: {
+      AccountData: "TokensAccountData",
+    },
+  },
+  types: {
+    ...typesFromDefs(zeitgeistDefinitions),
+    BalanceInfo: {
+      amount: "Balance",
+    },
+    TokensAccountData: {
+      free: "Balance",
+      reserved: "Balance",
+      frozen: "Balance",
+    },
+  },
+});
+
+export const lazyInitApi = (
+  endpoint?: string
+): [WsProvider, () => Promise<ApiPromise>] => {
+  const provider = new WsProvider(endpoint);
+  return [provider, () => ApiPromise.create(constructApiOptions(provider))];
+};
+
 export const initApi = (
   endpoint = "wss://bsr.zeitgeist.pm"
 ): Promise<ApiPromise> => {
-  return ApiPromise.create({
-    provider: new WsProvider(endpoint),
-    rpc: {
-      predictionMarkets: {
-        marketOutcomeShareId: {
-          description: "Get the market outcome share identifier.",
-          params: [
-            {
-              name: "market_id",
-              type: "MarketId",
-            },
-            {
-              name: "outcome",
-              type: "u16",
-            },
-            {
-              name: "at",
-              type: "Hash",
-              isOptional: true,
-            },
-          ],
-          type: "Asset",
-        },
-      },
-      swaps: {
-        poolSharesId: {
-          description: "Gets the share identifier for the pool shares.",
-          params: [
-            {
-              name: "pool_id",
-              type: "u128",
-            },
-            {
-              name: "at",
-              type: "Hash",
-              isOptional: true,
-            },
-          ],
-          type: "Asset",
-        },
-        poolAccountId: {
-          description: "Gets the pool's account.",
-          params: [
-            {
-              name: "pool_id",
-              type: "u128",
-            },
-            {
-              name: "at",
-              type: "Hash",
-              isOptional: true,
-            },
-          ],
-          type: "AccountId",
-        },
-        getSpotPrice: {
-          description: "Gets the spot price for a pool's in and out assets.",
-          params: [
-            {
-              name: "pool_id",
-              type: "u128",
-            },
-            {
-              name: "asset_in",
-              type: "Asset",
-            },
-            {
-              name: "asset_out",
-              type: "Asset",
-            },
-            {
-              name: "at",
-              type: "Hash",
-              isOptional: true,
-            },
-          ],
-          type: "SerdeWrapper",
-        },
-        getSpotPrices: {
-          description: "Gets spot prices for a range of blocks",
-          params: [
-            {
-              name: "pool_id",
-              type: "u128",
-            },
-            {
-              name: "asset_in",
-              type: "Asset",
-            },
-            {
-              name: "asset_out",
-              type: "Asset",
-            },
-            {
-              name: "blocks",
-              type: "Vec<BlockNumber>",
-            },
-          ],
-          type: "Vec<SerdeWrapper>",
-        },
-      },
-    },
-    typesAlias: {
-      tokens: {
-        AccountData: "TokensAccountData",
-      },
-    },
-    types: {
-      ...typesFromDefs(zeitgeistDefinitions),
-      BalanceInfo: {
-        amount: "Balance",
-      },
-      TokensAccountData: {
-        free: "Balance",
-        reserved: "Balance",
-        frozen: "Balance",
-      },
-    },
-  });
+  return ApiPromise.create(constructApiOptions(new WsProvider(endpoint)));
 };
 
 export const unsubOrWarns = (unsub: () => void) => {

--- a/packages/sdk/src/util/polkadot.ts
+++ b/packages/sdk/src/util/polkadot.ts
@@ -141,7 +141,7 @@ export const constructApiOptions = (provider: WsProvider) => ({
 export const lazyInitApi = (
   endpoint?: string
 ): [WsProvider, () => Promise<ApiPromise>] => {
-  const provider = new WsProvider(endpoint);
+  const provider = new WsProvider(endpoint, 1200, undefined, 15000);
   return [provider, () => ApiPromise.create(constructApiOptions(provider))];
 };
 


### PR DESCRIPTION
Catch errors and throw after a set threshold off tries when trying to initialise api.
This prevents the console from being flooded by orphaned connections when it is abandoned by consuming code.

**Fixes:** zeitgeistpm/ui#150